### PR TITLE
Catch errors when contacts support is disabled

### DIFF
--- a/imp/config/hooks.php
+++ b/imp/config/hooks.php
@@ -17,16 +17,27 @@ class IMP_Hooks
         switch ($pref) {
         case 'add_source':
             // Dynamically set the add_source preference.
+            try {
+                $add_source = $GLOBALS['registry']->call('contacts/getDefaultShare');
+            }
+            catch (Horde_Exception $e) {
+                $add_source = $value;
+            }
             return is_null($username)
                 ? $value
-                : $GLOBALS['registry']->call('contacts/getDefaultShare');
+                : $add_source;
 
 
         case 'search_fields':
         case 'search_sources':
             // Dynamically set the search_fields/search_sources preferences.
             if (!is_null($username)) {
-                $sources = $GLOBALS['registry']->call('contacts/sources');
+                try {
+                    $sources = $GLOBALS['registry']->call('contacts/sources');
+                }
+                catch (Horde_Exception $e) {
+                    $sources = array();
+                }
 
                 if ($pref == 'search_fields') {
                     $out = array();


### PR DESCRIPTION
Avoid failing if the horde setup doesn't enable contacts, i.e.

```
$this->applications['turba']['status'] = 'inactive';
```